### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,12 +3,16 @@ import os
 import json
 import uuid
 import requests
+import logging
 from flask import Flask, request, jsonify, render_template, session
 from flask_cors import CORS
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)  # Set a secret key for session management
 CORS(app)
+
+# Configure logging
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(levelname)s %(message)s')
 
 # Replace with your actual API key
 API_KEY = os.getenv('TOKEN')
@@ -65,7 +69,8 @@ def generate_content():
 
         return jsonify({'response': response_text, 'response_id': str(uuid.uuid4())}), 200
     except requests.exceptions.RequestException as e:
-        return jsonify({'error': str(e)}), 500
+        logging.error("RequestException: %s", str(e))
+        return jsonify({'error': 'An internal error occurred'}), 500
     except Exception:  # Catching general exceptions
         return jsonify({'error': 'An unexpected error occurred'}), 500
 


### PR DESCRIPTION
Fixes [https://github.com/Lain0x0/MyAI/security/code-scanning/2](https://github.com/Lain0x0/MyAI/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the response.

1. Import the `logging` module.
2. Configure the logging settings.
3. Replace the line that returns the exception message with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
